### PR TITLE
Refactor plugin nomenclature from GPR to RasterLinker

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -26,11 +26,11 @@
 
 # noinspection PyPep8Naming
 def classFactory(iface):  # pylint: disable=invalid-name
-    """Load GPR class from file GPR.
+    """Load RasterLinkerPlugin class from file gpr_linker.
 
     :param iface: A QGIS interface instance.
     :type iface: QgsInterface
     """
     #
-    from .gpr_linker import GPR
-    return GPR(iface)
+    from .gpr_linker import RasterLinkerPlugin
+    return RasterLinkerPlugin(iface)

--- a/gpr_linker.py
+++ b/gpr_linker.py
@@ -42,11 +42,11 @@ from .polygon_draw_tool import PolygonDrawTool
 
 
 from .resources import *
-from .gpr_linker_dialog import GPRDialog
+from .gpr_linker_dialog import RasterLinkerDialog
 import os.path
 
 
-class GPR:
+class RasterLinkerPlugin:
     """QGIS Plugin Implementation."""
 
     def __init__(self, iface):
@@ -54,12 +54,12 @@ class GPR:
         self.iface = iface
         self.plugin_dir = os.path.dirname(__file__)
         self.actions = []
-        self.menu = self.tr(u'&GPR')
+        self.menu = self.tr(u'&RasterLinker')
         self.first_start = None
 
     # Translation helper
     def tr(self, message):
-        return QCoreApplication.translate('GPR', message)
+        return QCoreApplication.translate('RasterLinker', message)
 
     # Add actions to the toolbar/menu
     def add_action(self, icon_path, text, callback, parent=None):
@@ -74,20 +74,20 @@ class GPR:
     def initGui(self):
         """Initialize the GUI."""
         icon_path = ':/plugins/gpr_linker/icon.png'
-        self.add_action(icon_path, text=self.tr(u'GRP Linker'), callback=self.run, parent=self.iface.mainWindow())
+        self.add_action(icon_path, text=self.tr(u'Raster Linker'), callback=self.run, parent=self.iface.mainWindow())
         self.first_start = True
 
     def unload(self):
         """Unload the plugin."""
         for action in self.actions:
-            self.iface.removePluginMenu(self.tr(u'&GPR'), action)
+            self.iface.removePluginMenu(self.tr(u'&RasterLinker'), action)
             self.iface.removeToolBarIcon(action)
 
     def run(self):
         """Esegue il plugin."""
         if self.first_start:
             self.first_start = False
-            self.dlg = GPRDialog()
+            self.dlg = RasterLinkerDialog()
             self.populate_group_list()
 
             # Collega i segnali ai metodi

--- a/gpr_linker_dialog.py
+++ b/gpr_linker_dialog.py
@@ -10,7 +10,7 @@
 from PyQt5.QtWidgets import QDialog
 from .gpr_linker_dialog_base import Ui_Dialog
 
-class GPRDialog(QDialog, Ui_Dialog):
+class RasterLinkerDialog(QDialog, Ui_Dialog):
     def __init__(self, parent=None):
-        super(GPRDialog, self).__init__(parent)
+        super(RasterLinkerDialog, self).__init__(parent)
         self.setupUi(self)  # Imposta l'interfaccia utente


### PR DESCRIPTION
### Motivation
- Remove plugin-specific `GPR` naming and adopt a more generic, descriptive name for the plugin and its UI components. 
- Ensure UI-facing labels and translation context reflect the new generic name for clarity and future reuse.

### Description
- Renamed the main plugin class `GPR` to `RasterLinkerPlugin` and updated the plugin bootstrap to import/instantiate `RasterLinkerPlugin` in `__init__.py`.
- Renamed the dialog class `GPRDialog` to `RasterLinkerDialog` and updated its constructor `super(...)` call in `gpr_linker_dialog.py`.
- Updated imports and dialog instantiation in `gpr_linker.py` to `from .gpr_linker_dialog import RasterLinkerDialog` and `self.dlg = RasterLinkerDialog()`.
- Updated menu text and translation context from `GPR`/`GRP Linker` to `RasterLinker`/`Raster Linker` and adjusted `classFactory` docstring accordingly; files modified: `__init__.py`, `gpr_linker.py`, `gpr_linker_dialog.py`.

### Testing
- Ran `python -m py_compile __init__.py gpr_linker.py gpr_linker_dialog.py` and the bytecode compilation check completed successfully.
- Searched the codebase for legacy identifiers with `rg` and confirmed no remaining occurrences of `class GPR`, `GPRDialog`, or translation/menu keys referencing `GPR`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699301579058832bbdb47ee87ccdf513)