### PR TITLE
Replace QDialog with QDRefactor polygon-grid workflow: oriented area,…

### DIFF
--- a/polygon_draw_tool.py
+++ b/polygon_draw_tool.py
@@ -1,82 +1,345 @@
-from qgis.gui import QgsMapToolEmitPoint
-from qgis.core import QgsVectorLayer, QgsFeature, QgsGeometry, QgsProject, QgsPointXY
-from PyQt5.QtWidgets import QMessageBox
+import math
+
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QColor
+from qgis.gui import QgsMapToolEmitPoint, QgsRubberBand, QgsVertexMarker
+from qgis.core import QgsVectorLayer, QgsFeature, QgsGeometry, QgsProject, QgsWkbTypes, QgsPointXY
+from PyQt5.QtWidgets import QMessageBox, QInputDialog, QApplication
+
 
 class PolygonDrawTool(QgsMapToolEmitPoint):
     """
-    Strumento per disegnare un poligono interattivamente sulla mappa.
+    Strumento per disegnare un poligono.
+
+    Modalita 1 (default): disegno libero con click sinistro e chiusura con destro/Invio.
+    Modalita 2 (orientata): click primo punto, orienta col mouse, poi tasto D
+    (o click centrale) per bloccare
+    orientamento e inserire lunghezza/larghezza numeriche del rettangolo.
     """
+
     def __init__(self, canvas, parent_plugin):
         super().__init__(canvas)
         self.canvas = canvas
         self.parent_plugin = parent_plugin
-        self.points = []  # Lista dei vertici del poligono
+        self.points = []
+        self.current_mouse_point = None
+        self.vertex_markers = []
+        self.last_total_length = 20.0
+        self.last_total_width = 20.0
+        self.locked_angle = None
+        self.dimension_pick_mode = None
+        self.pending_length = None
+        self.orthogonal_lock_enabled = False
 
-        # Controlla se il canvas è valido
+        self.line_rubber_band = QgsRubberBand(self.canvas, QgsWkbTypes.LineGeometry)
+        self.line_rubber_band.setColor(QColor(255, 140, 0))
+        self.line_rubber_band.setWidth(2)
+
+        self.polygon_rubber_band = QgsRubberBand(self.canvas, QgsWkbTypes.PolygonGeometry)
+        self.polygon_rubber_band.setStrokeColor(QColor(255, 140, 0))
+        self.polygon_rubber_band.setFillColor(QColor(255, 140, 0, 50))
+        self.polygon_rubber_band.setWidth(1)
+
         if not self.canvas:
-            QMessageBox.critical(None, "Errore", "Canvas non valido!")
+            QMessageBox.critical(None, "Errore", "Canvas non valido.")
 
     def canvasReleaseEvent(self, event):
-        """
-        Aggiunge un vertice al poligono quando si clicca sulla mappa.
-        """
         try:
-            point = self.toMapCoordinates(event.pos())
-            self.points.append(point)
-            QMessageBox.information(None, "Debug", f"Punto aggiunto: {point.x()}, {point.y()}")
+            shift_active = self._shift_active(event)
+            axis_constraint = shift_active or self.orthogonal_lock_enabled
+            if event.button() == Qt.MiddleButton:
+                self._lock_orientation_and_build_rectangle()
+                return
+            if event.button() == Qt.LeftButton:
+                point = self._map_point_with_snap(event)
+                if len(self.points) >= 1 and axis_constraint:
+                    point = self._axis_snapped_point(self.points[0], point)
+                if self.dimension_pick_mode is not None:
+                    self._handle_canvas_dimension_pick(point)
+                    return
+                if len(self.points) >= 1 and axis_constraint:
+                    angle = self._compute_angle(self.points[0], point)
+                    if angle is None:
+                        QMessageBox.warning(None, "Orientamento", "Orientamento non valido.")
+                        return
+                    self.current_mouse_point = point
+                    self.locked_angle = angle
+                    self._begin_dimension_mode_selection()
+                    return
+                self.points.append(point)
+                self._add_vertex_marker(point)
+                self._update_preview()
+            elif event.button() == Qt.RightButton:
+                self.finish_polygon()
         except Exception as e:
             QMessageBox.critical(None, "Errore", f"Errore durante l'aggiunta del punto: {e}")
 
-
+    def canvasMoveEvent(self, event):
+        if not self.points:
+            return
+        point = self._map_point_with_snap(event)
+        if len(self.points) >= 1 and (self._shift_active(event) or self.orthogonal_lock_enabled):
+            point = self._axis_snapped_point(self.points[0], point)
+        self.current_mouse_point = point
+        self._update_preview()
 
     def keyPressEvent(self, event):
+        if event.key() == Qt.Key_X:
+            self.orthogonal_lock_enabled = not self.orthogonal_lock_enabled
+            state = "attivo" if self.orthogonal_lock_enabled else "disattivo"
+            QMessageBox.information(None, "Vincolo ortogonale", f"Vincolo 0/90 {state}.")
+            return
+
+        if event.key() == Qt.Key_D or (event.modifiers() & Qt.ControlModifier and event.key() == Qt.Key_D):
+            self._lock_orientation_and_build_rectangle()
+            return
+
+        if event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            self.finish_polygon()
+        elif event.key() == Qt.Key_Escape:
+            self.reset()
+            self.canvas.unsetMapTool(self)
+            QMessageBox.information(None, "Annullato", "Disegno poligono annullato.")
+
+    def _lock_orientation_and_build_rectangle(self):
+        if not self.points:
+            QMessageBox.information(None, "Orientamento", "Fai prima click sul punto di origine.")
+            return
+
+        origin = self.points[0]
+        reference = self.current_mouse_point
+        if reference is None and len(self.points) > 1:
+            reference = self.points[1]
+
+        if reference is None:
+            QMessageBox.information(
+                None,
+                "Orientamento",
+                "Muovi il mouse per orientare la base, poi premi D (oppure click centrale)."
+            )
+            return
+
+        angle = self._compute_angle(origin, reference)
+        if angle is None:
+            QMessageBox.warning(None, "Orientamento", "Orientamento non valido: scegli una direzione diversa.")
+            return
+        self.locked_angle = angle
+        self._begin_dimension_mode_selection()
+
+    def _begin_dimension_mode_selection(self):
+        choice = QMessageBox(None)
+        choice.setWindowTitle("Dimensioni area")
+        choice.setText("Come vuoi definire lunghezza e larghezza?")
+        manual_btn = choice.addButton("Inserimento manuale", QMessageBox.AcceptRole)
+        canvas_btn = choice.addButton("Da canvas", QMessageBox.ActionRole)
+        cancel_btn = choice.addButton(QMessageBox.Cancel)
+        choice.exec_()
+
+        clicked = choice.clickedButton()
+        if clicked == cancel_btn:
+            return
+        if clicked == manual_btn:
+            self._build_rectangle_from_dialog()
+            return
+        if clicked == canvas_btn:
+            self.dimension_pick_mode = "length"
+            self.pending_length = None
+            QMessageBox.information(
+                None,
+                "Da canvas",
+                "Click 1: imposta la lunghezza lungo l'orientamento bloccato. "
+                "Click 2: imposta la larghezza."
+            )
+
+    def _compute_angle(self, origin, reference):
+        dx = reference.x() - origin.x()
+        dy = reference.y() - origin.y()
+        if math.hypot(dx, dy) < 1e-9:
+            return None
+        return math.atan2(dy, dx)
+
+    def _axis_snapped_point(self, origin, point):
+        dx = point.x() - origin.x()
+        dy = point.y() - origin.y()
+        if abs(dx) >= abs(dy):
+            return QgsPointXY(point.x(), origin.y())
+        return QgsPointXY(origin.x(), point.y())
+
+    def _shift_active(self, event=None):
         """
-        Completa il poligono quando l'utente preme Invio.
+        Rilevamento robusto di Shift: evento mouse + stato tastiera globale.
         """
-        if event.key() == Qt.Key_Return:  # Invio
-            if len(self.points) < 3:
-                QMessageBox.warning(None, "Errore", "Un poligono deve avere almeno 3 vertici!")
+        if event is not None and (event.modifiers() & Qt.ShiftModifier):
+            return True
+        return bool(QApplication.keyboardModifiers() & Qt.ShiftModifier)
+
+    def _build_rectangle_from_dialog(self):
+        length, ok_len = QInputDialog.getDouble(
+            None,
+            "Lunghezza totale area",
+            "Inserisci lunghezza totale:",
+            self.last_total_length,
+            0.0001,
+            1e12,
+            3,
+        )
+        if not ok_len:
+            return
+
+        width, ok_wid = QInputDialog.getDouble(
+            None,
+            "Larghezza totale area",
+            "Inserisci larghezza totale:",
+            self.last_total_width,
+            0.0001,
+            1e12,
+            3,
+        )
+        if not ok_wid:
+            return
+
+        self.last_total_length = length
+        self.last_total_width = width
+        self._build_rectangle_from_values(length, width)
+
+    def _handle_canvas_dimension_pick(self, point):
+        if not self.points or self.locked_angle is None:
+            return
+
+        origin = self.points[0]
+        ux = (math.cos(self.locked_angle), math.sin(self.locked_angle))
+        uy = (-math.sin(self.locked_angle), math.cos(self.locked_angle))
+
+        vx = point.x() - origin.x()
+        vy = point.y() - origin.y()
+
+        if self.dimension_pick_mode == "length":
+            length = abs(vx * ux[0] + vy * ux[1])
+            if length <= 0:
+                QMessageBox.warning(None, "Valore non valido", "Lunghezza non valida, riprova.")
                 return
+            self.pending_length = length
+            self.dimension_pick_mode = "width"
+            QMessageBox.information(None, "Da canvas", "Ora clicca per impostare la larghezza.")
+            return
 
-            QMessageBox.information(None, "Debug", f"Creazione del poligono con {len(self.points)} vertici")
+        if self.dimension_pick_mode == "width":
+            width = abs(vx * uy[0] + vy * uy[1])
+            if width <= 0:
+                QMessageBox.warning(None, "Valore non valido", "Larghezza non valida, riprova.")
+                return
+            self.last_total_length = self.pending_length
+            self.last_total_width = width
+            self.dimension_pick_mode = None
+            self._build_rectangle_from_values(self.pending_length, width)
 
-            try:
-                # Verifica il CRS del progetto
-                project_crs = QgsProject.instance().crs()
-                QMessageBox.information(None, "Debug", f"CRS del progetto: {project_crs.authid()}")
+    def _build_rectangle_from_values(self, length, width):
+        if not self.points or self.locked_angle is None:
+            return
 
-                # Crea un layer vettoriale in memoria con lo stesso CRS del progetto
-                polygon_layer = QgsVectorLayer(f"Polygon?crs={project_crs.authid()}", "Poligono Disegnato", "memory")
-                if not polygon_layer.isValid():
-                    raise Exception("Errore nella creazione del layer poligonale!")
+        origin = self.points[0]
+        ux = (math.cos(self.locked_angle), math.sin(self.locked_angle))
+        uy = (-math.sin(self.locked_angle), math.cos(self.locked_angle))
 
-                pr = polygon_layer.dataProvider()
+        p1 = origin
+        p2 = QgsPointXY(p1.x() + length * ux[0], p1.y() + length * ux[1])
+        p3 = QgsPointXY(p2.x() + width * uy[0], p2.y() + width * uy[1])
+        p4 = QgsPointXY(p1.x() + width * uy[0], p1.y() + width * uy[1])
 
-                # Debug dei punti raccolti
-                for i, point in enumerate(self.points):
-                    QMessageBox.information(None, "Debug", f"Punto {i}: {point.x()}, {point.y()}")
+        self._set_points([p1, p2, p3, p4])
+        self.finish_polygon()
 
-                # Crea il poligono
-                feature = QgsFeature()
-                feature.setGeometry(QgsGeometry.fromPolygonXY([self.points]))
-                pr.addFeature(feature)
-                polygon_layer.updateExtents()
+    def finish_polygon(self):
+        if len(self.points) < 3:
+            QMessageBox.warning(None, "Errore", "Un poligono deve avere almeno 3 vertici.")
+            return
 
-                # Aggiungi il layer al progetto
-                QgsProject.instance().addMapLayer(polygon_layer)
-                QMessageBox.information(None, "Successo", "Poligono creato e aggiunto alla mappa!")
+        try:
+            project_crs = QgsProject.instance().crs()
+            polygon_layer = QgsVectorLayer(f"Polygon?crs={project_crs.authid()}", "Poligono Disegnato", "memory")
+            if not polygon_layer.isValid():
+                raise Exception("Errore nella creazione del layer poligonale.")
 
-                # Resetta il tool
-                self.points = []
-                self.canvas.unsetMapTool()
-            except Exception as e:
-                QMessageBox.critical(None, "Errore", f"Errore durante la creazione del poligono: {e}")
+            pr = polygon_layer.dataProvider()
+            feature = QgsFeature()
+            feature.setGeometry(QgsGeometry.fromPolygonXY([self.points]))
+            pr.addFeature(feature)
+            polygon_layer.updateExtents()
+            QgsProject.instance().addMapLayer(polygon_layer)
 
+            if hasattr(self.parent_plugin, "create_grid_from_drawn_polygon"):
+                self.parent_plugin.create_grid_from_drawn_polygon(polygon_layer)
 
+            QMessageBox.information(None, "Successo", "Poligono creato.")
+        except Exception as e:
+            QMessageBox.critical(None, "Errore", f"Errore durante la creazione del poligono: {e}")
+        finally:
+            self.reset()
+            self.canvas.unsetMapTool(self)
 
+    def _set_points(self, points):
+        self.points = list(points)
+        self.current_mouse_point = None
+        for marker in self.vertex_markers:
+            self.canvas.scene().removeItem(marker)
+        self.vertex_markers = []
+        for point in self.points:
+            self._add_vertex_marker(point)
+        self._update_preview()
+
+    def _map_point_with_snap(self, event):
+        """
+        Usa lo snapping di QGIS se disponibile/valido; fallback su coordinate libere.
+        """
+        try:
+            snap_utils = self.canvas.snappingUtils()
+            if snap_utils is not None:
+                match = snap_utils.snapToMap(event.pos())
+                if match.isValid():
+                    return match.point()
+        except Exception:
+            pass
+        return self.toMapCoordinates(event.pos())
+
+    def _add_vertex_marker(self, point):
+        marker = QgsVertexMarker(self.canvas)
+        marker.setCenter(point)
+        marker.setColor(QColor(220, 20, 60))
+        marker.setIconType(QgsVertexMarker.ICON_CROSS)
+        marker.setIconSize(10)
+        marker.setPenWidth(2)
+        self.vertex_markers.append(marker)
+
+    def _update_preview(self):
+        self.line_rubber_band.reset(QgsWkbTypes.LineGeometry)
+        for p in self.points:
+            self.line_rubber_band.addPoint(p, False)
+        if self.current_mouse_point is not None:
+            self.line_rubber_band.addPoint(self.current_mouse_point, True)
+        elif self.points:
+            self.line_rubber_band.addPoint(self.points[-1], True)
+
+        self.polygon_rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+        ring = list(self.points)
+        if self.current_mouse_point is not None:
+            ring.append(self.current_mouse_point)
+        if len(ring) >= 3:
+            closed_ring = ring + [ring[0]]
+            self.polygon_rubber_band.setToGeometry(QgsGeometry.fromPolygonXY([closed_ring]), None)
 
     def reset(self):
-        """
-        Resetta i punti selezionati.
-        """
         self.points = []
+        self.current_mouse_point = None
+        self.locked_angle = None
+        self.dimension_pick_mode = None
+        self.pending_length = None
+        self.orthogonal_lock_enabled = False
+        self.line_rubber_band.reset(QgsWkbTypes.LineGeometry)
+        self.polygon_rubber_band.reset(QgsWkbTypes.PolygonGeometry)
+        for marker in self.vertex_markers:
+            self.canvas.scene().removeItem(marker)
+        self.vertex_markers = []
+
+    def deactivate(self):
+        self.reset()
+        super().deactivate()

--- a/polygon_grid_creator.py
+++ b/polygon_grid_creator.py
@@ -1,93 +1,165 @@
-
 # -*- coding: utf-8 -*-
 """
 polygon_grid_creator.py
-Modulo per creare una griglia basata su un layer poligonale disegnato dall'utente.
+Genera una griglia di celle poligonali orientate in base al poligono disegnato.
 """
 
+import math
 from qgis.core import (
-    QgsVectorLayer,
     QgsFeature,
-    QgsGeometry,
     QgsField,
-    QgsProject,
+    QgsGeometry,
     QgsPointXY,
+    QgsProject,
+    QgsVectorLayer,
 )
 from qgis.PyQt.QtCore import QVariant
-import numpy as np
 
 
-def create_grid_from_polygon(polygon_layer, distance_x, distance_y):
+def _largest_edge_angle_rad(geometry):
     """
-    Crea una griglia basata su un layer poligonale.
+    Calcola l'orientamento (radianti) dal lato più lungo del minimum rotated rectangle.
+    """
+    ombb = geometry.orientedMinimumBoundingBox()
+    box_geom = ombb[0] if isinstance(ombb, (tuple, list)) else ombb
+
+    polygon = box_geom.asPolygon()
+    if not polygon or not polygon[0] or len(polygon[0]) < 2:
+        return 0.0
+
+    ring = polygon[0]
+    best_len = -1.0
+    best_angle = 0.0
+    for i in range(len(ring) - 1):
+        p1 = ring[i]
+        p2 = ring[i + 1]
+        dx = p2.x() - p1.x()
+        dy = p2.y() - p1.y()
+        seg_len = math.hypot(dx, dy)
+        if seg_len > best_len:
+            best_len = seg_len
+            best_angle = math.atan2(dy, dx)
+    return best_angle
+
+
+def _build_rotated_cell(u0, u1, v0, v1, ux, uy):
+    """
+    Crea la geometria di una cella usando coordinate locali (u, v) ruotate.
+    """
+    p1 = QgsPointXY(u0 * ux[0] + v0 * uy[0], u0 * ux[1] + v0 * uy[1])
+    p2 = QgsPointXY(u1 * ux[0] + v0 * uy[0], u1 * ux[1] + v0 * uy[1])
+    p3 = QgsPointXY(u1 * ux[0] + v1 * uy[0], u1 * ux[1] + v1 * uy[1])
+    p4 = QgsPointXY(u0 * ux[0] + v1 * uy[0], u0 * ux[1] + v1 * uy[1])
+    return QgsGeometry.fromPolygonXY([[p1, p2, p3, p4, p1]])
+
+
+def _axis_breaks(min_value, max_value, step):
+    """
+    Genera breakpoints ancorati al bordo minimo dell'area (no snap a griglia globale).
+    """
+    if max_value <= min_value:
+        return [min_value, max_value]
+
+    values = [min_value]
+    current = min_value
+    eps = step * 1e-9
+    while (current + step) < (max_value - eps):
+        current += step
+        values.append(current)
+    values.append(max_value)
+    return values
+
+
+def create_grid_from_polygon(polygon_layer, distance_x, distance_y, area_name=None, cell_prefix=None):
+    """
+    Crea celle poligonali orientate e ritagliate sul poligono di input.
 
     Args:
-        polygon_layer (QgsVectorLayer): Layer poligonale disegnato dall'utente.
-        distance_x (float): Distanza tra le linee sull'asse X.
-        distance_y (float): Distanza tra le linee sull'asse Y.
+        polygon_layer (QgsVectorLayer): Layer poligonale.
+        distance_x (float): Passo lungo asse principale.
+        distance_y (float): Passo lungo asse secondario.
+        area_name (str): Nome area principale.
+        cell_prefix (str): Prefisso celle.
 
     Returns:
-        QgsVectorLayer: Layer vettoriale della griglia.
+        QgsVectorLayer: Layer poligonale delle celle.
     """
-    if polygon_layer.geometryType() != QgsVectorLayer.PolygonGeometry:
-        raise ValueError("Il layer selezionato non è un layer poligonale!")
+    if distance_x <= 0 or distance_y <= 0:
+        raise ValueError("X lenght e Y lenght devono essere maggiori di zero.")
 
-    # Crea un nuovo layer di linee in memoria per la griglia
+    input_geoms = [f.geometry() for f in polygon_layer.getFeatures() if f.geometry() and not f.geometry().isEmpty()]
+    if not input_geoms:
+        raise ValueError("Nessuna geometria valida nel layer poligonale.")
+
+    union_geom = QgsGeometry.unaryUnion(input_geoms)
+    if union_geom is None or union_geom.isEmpty():
+        raise ValueError("Impossibile costruire la geometria unita dell'area.")
+
+    area_name = (area_name or "Area_Indagine").strip()
+    cell_prefix = (cell_prefix or f"{area_name}_cell").strip()
+
+    angle = _largest_edge_angle_rad(union_geom)
+    ux = (math.cos(angle), math.sin(angle))
+    uy = (-math.sin(angle), math.cos(angle))
+
+    projections_u = []
+    projections_v = []
+    for vertex in union_geom.vertices():
+        x = vertex.x()
+        y = vertex.y()
+        projections_u.append(x * ux[0] + y * ux[1])
+        projections_v.append(x * uy[0] + y * uy[1])
+
+    if not projections_u or not projections_v:
+        raise ValueError("Impossibile calcolare l'orientamento della griglia.")
+
+    u_min = min(projections_u)
+    u_max = max(projections_u)
+    v_min = min(projections_v)
+    v_max = max(projections_v)
+
+    u_values = _axis_breaks(u_min, u_max, distance_x)
+    v_values = _axis_breaks(v_min, v_max, distance_y)
+
     grid_layer = QgsVectorLayer(
-        f"LineString?crs={polygon_layer.crs().authid()}", "Griglia Poligonale", "memory"
+        f"Polygon?crs={polygon_layer.crs().authid()}",
+        f"{cell_prefix}_grid",
+        "memory",
     )
-    pr = grid_layer.dataProvider()
-
-    # Aggiungi campi TID/LID
-    pr.addAttributes([
-        QgsField("ID", QVariant.String),
-        QgsField("Type", QVariant.String)
-    ])
+    provider = grid_layer.dataProvider()
+    provider.addAttributes(
+        [
+            QgsField("cell_id", QVariant.String),
+            QgsField("area", QVariant.String),
+            QgsField("row", QVariant.Int),
+            QgsField("col", QVariant.Int),
+        ]
+    )
     grid_layer.updateFields()
 
     features = []
+    row_idx = 0
+    for j in range(len(v_values) - 1):
+        v0 = v_values[j]
+        v1 = v_values[j + 1]
+        row_idx += 1
+        col_idx = 0
+        for i in range(len(u_values) - 1):
+            u0 = u_values[i]
+            u1 = u_values[i + 1]
+            col_idx += 1
 
-    # Itera attraverso i poligoni e genera la griglia per ciascuno
-    for feature in polygon_layer.getFeatures():
-        geom = feature.geometry()
-        if not geom:
-            continue
+            cell_geom = _build_rotated_cell(u0, u1, v0, v1, ux, uy)
+            clipped = cell_geom.intersection(union_geom)
+            if clipped.isEmpty() or clipped.area() <= 0:
+                continue
 
-        # Ottieni i bounding box del poligono
-        bbox = geom.boundingBox()
-        x_min, x_max = bbox.xMinimum(), bbox.xMaximum()
-        y_min, y_max = bbox.yMinimum(), bbox.yMaximum()
+            feat = QgsFeature(grid_layer.fields())
+            feat.setGeometry(clipped)
+            feat.setAttributes([f"{cell_prefix}_{row_idx:03d}_{col_idx:03d}", area_name, row_idx, col_idx])
+            features.append(feat)
 
-        # Usa numpy per generare intervalli per valori float
-        x_values = np.arange(x_min, x_max + distance_x, distance_x)
-        y_values = np.arange(y_min, y_max + distance_y, distance_y)
-
-        # Crea le linee TID (verticali)
-        for i, x in enumerate(x_values):
-            line_geom = QgsGeometry.fromPolylineXY([
-                QgsPointXY(x, y_min),
-                QgsPointXY(x, y_max)
-            ])
-            tid_feature = QgsFeature()
-            tid_feature.setGeometry(line_geom)
-            tid_feature.setAttributes([f"TID_{i}", "TID"])
-            features.append(tid_feature)
-
-        # Crea le linee LID (orizzontali)
-        for i, y in enumerate(y_values):
-            line_geom = QgsGeometry.fromPolylineXY([
-                QgsPointXY(x_min, y),
-                QgsPointXY(x_max, y)
-            ])
-            lid_feature = QgsFeature()
-            lid_feature.setGeometry(line_geom)
-            lid_feature.setAttributes([f"LID_{i}", "LID"])
-            features.append(lid_feature)
-
-    # Aggiungi le feature al layer
-    pr.addFeatures(features)
+    provider.addFeatures(features)
     grid_layer.updateExtents()
-
-    # Aggiungi il layer al progetto
     QgsProject.instance().addMapLayer(grid_layer)
     return grid_layer


### PR DESCRIPTION
Refactor polygon-grid workflow: oriented area, snapping preview, and aligned cell subdivision

Reworked the Draw Polygon flow to support oriented survey areas and polygon-cell subdivision.
Added interactive drawing preview (vertex markers + dynamic rubber-band line/polygon).
Integrated QGIS snapping for both clicks and mouse-move preview.
Added orientation lock workflows:
D / middle-click to lock orientation and choose dimensions input mode
optional orthogonal lock (0/90) with X toggle
Shift-based orthogonal behavior where available
Added flexible size input:
manual numeric input (length/width dialogs)
or two-click capture from canvas (length then width)
Fixed grid-cell alignment to avoid edge offsets (no more first/last partial mismatch like 0.7/0.3 on a 10x10 with 1m step).
Updated naming workflow from UI (AreaName|CellPrefix) and improved user instructions in the docked plugin UI.